### PR TITLE
Fix Facter api error

### DIFF
--- a/lib/puppet/type/midonet_host_registry.rb
+++ b/lib/puppet/type/midonet_host_registry.rb
@@ -77,7 +77,7 @@ Puppet::Type.newtype(:midonet_host_registry) do
     desc "IP address that will be used to as the underlay layer to
           create the tunnels. It will take the fact $ipaddress by
           default"
-    defaultto Facter['ipaddress'].value
+    defaultto Facter.value('ipaddress')
     validate do |value|
       unless value =~ /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$/
         raise ArgumentError, "'%s' is not a valid IPv4 address" % value


### PR DESCRIPTION
Fix Facter['ipaddress'].value => Facter.value('ipaddress')

I couldn't get this to compile otherwise, nor can I find puppet documentation that suggests the left is the correct syntax.

https://puppet.com/docs/facter/3.9/fact_overview.html#example-returning-an-array-of-network-interfaces

additionally, the syntax on the right is used elsewhere:

https://github.com/openstack/puppet-midonet/blob/aa327815d1b0f0de83ce5a82c3d3145cf71915ca/lib/puppet/parser/functions/c7_int_name.rb#L14